### PR TITLE
Implement double-buffered media playback

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -8,10 +8,14 @@ img{max-width:100%;}
 
 #layout{width:1920px;height:1080px;overflow: hidden;;position: relative;;background-color: #1b232e;margin:0 auto;display:flex;flex-direction: column;box-shadow: 0 0 15px rgba(0,0,0,0.3);}
 #did{display:table;table-layout: fixed;width:100%;overflow: hidden;}
-.video_area{width:1442px;display: table-cell;text-align: left;}
-.video_area video{width: 100%;height: 100%;display: block;height:810px;}
-.image_area{display: table-cell;}
-.image_area img{width:100%;height: 100%;display: block;height:810px;}
+.video_area{width:1442px;display: table-cell;text-align: left;position: relative;height:810px;}
+.image_area{display: table-cell;position: relative;height:810px;}
+.video_area .item,
+.image_area .item{position:absolute;left:0;top:0;width:100%;height:100%;opacity:0;transition:opacity .3s ease;pointer-events:none;}
+.video_area .item.is-active,
+.image_area .item.is-active{opacity:1;pointer-events:auto;z-index:1;}
+.video_area .item video,
+.image_area .item img{width:100%;height:100%;display:block;}
 #status{color:#fff;background-color: #1b232e;box-shadow: inset 0 0 10px rgb(23 144 148 / 25%);display: flex;height: 270px;overflow: hidden;position: relative;}
 #status:before{content:"";position: absolute;left:0;top:0;width:100%;height: 100%;transform: rotate(1deg);background-position: center 130px;background-repeat: no-repeat;background-size: 100% 200px;background-image: url('../images/bg.png');filter: grayscale(1);opacity: 0.08;}
 #status .info{width:450px;padding:30px 0 30px 45px;font-family: "Hyundai Sans Head";display: flex;flex-direction: column;position: relative;z-index: 1;}

--- a/index.html
+++ b/index.html
@@ -11,10 +11,20 @@
     <div id="layout">
         <div id="did">
             <div class="video_area">
-                <video src="./assets/videos/sample3.mp4" autoplay></video>
+                <div class="item is-active">
+                    <video src="./assets/videos/sample3.mp4" muted playsinline preload="auto"></video>
+                </div>
+                <div class="item">
+                    <video src="./assets/videos/sample2.mp4" muted playsinline preload="auto"></video>
+                </div>
             </div>
             <div class="image_area">
-                <img src="./assets/images/sample1.jpg">
+                <div class="item is-active">
+                    <img src="./assets/images/sample1.jpg" alt="">
+                </div>
+                <div class="item">
+                    <img src="./assets/images/sample2.jpg" alt="">
+                </div>
             </div>
         </div>
         <div id="status">


### PR DESCRIPTION
## Summary
- add paired video and image elements with CSS to support off-screen buffering during swaps
- overhaul the JavaScript controllers to preload media into standby buffers and swap them without visible pauses, including event playback handling

## Testing
- not run (no automated tests provided)


------
https://chatgpt.com/codex/tasks/task_e_68c9f92fc3a0832db5891a0238b420fd